### PR TITLE
Stop doing s3 backup

### DIFF
--- a/engine/main.py
+++ b/engine/main.py
@@ -16,7 +16,7 @@ from engine.constants import extract_hash_tags, ALLOWED_MESSAGE_STATUSES
 from gmail_setup.api import update_gmail_filter, untrash_message
 from gmail_setup.views import build_services
 from http_handler.settings import BASE_URL, WEBSITE, AWS_STORAGE_BUCKET_NAME, PERSPECTIVE_KEY
-from s3_storage import upload_attachments, download_attachments, download_message
+from s3_storage import upload_attachments, download_attachments
 from schema.models import *
 from smtp_handler.utils import *
 
@@ -1574,15 +1574,6 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
                 mail = MailResponse(From = 'no_reply@%s' % HOST, To = admin.email, Subject = '%s: %s' % (p.poster_email, new_subj))
                 mail['message-id'] = p.msg_id
                 mail['reply-to'] = p.poster_email
-
-                res = download_message(p.id, p.msg_id)
-                if not res['status']:
-                    logging.error("Error downloading original message")
-                else:
-                    original_msg = email.message_from_string(res['message'])
-                    mail['In-Reply-To'] = original_msg['In-Reply-To']
-                    mail['References'] = original_msg['References']
-                    mail['Cc'] = original_msg['Cc']
 
                 attachments = download_attachments(p.msg_id)
                 for a in attachments:

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -359,10 +359,6 @@ def handle_post_murmur(message, group, host, verified):
 
         post_id = res['post_id']
 
-        s3_res = upload_message(message, post_id, msg_id)
-        if not s3_res['status']:
-            logging.debug("Error uploading original post to s3; continuing anyway")
-
         subject = get_subject(message, res, group.name)
         mail = setup_post(message['From'], subject, group.name)
 
@@ -575,10 +571,6 @@ def handle_post_squadbox(message, group, host, verified):
             return
 
         post_id = res['post_id']
-
-        res = upload_message(message, post_id, msg_id)
-        if not res['status']:
-            logging.debug("Error uploading original post to s3; continuing anyway")
 
     # one of following is true: 
     # 1) sender is whitelisted


### PR DESCRIPTION
so we were using this to recreate the original reply-to, cc, and references fields on outgoing messages. I can't remember why that mattered in the first place - I think we maybe just did it for sake of completeness when recreating the message... I don't have time to implement this and thoroughly test it now so I'm creating an issue #52 but we should probably just store all message headers in the db along with the message itself. 