### PR TITLE
Clarify to use your own email address when signing up

### DIFF
--- a/browser/templates/registration/registration_form.html
+++ b/browser/templates/registration/registration_form.html
@@ -5,12 +5,11 @@
 	<div class="accounts">
 		<h3>Register Account</h3>
 		<hr />
-		{% if website == 'squadbox' %}
 		<i>Note: Squadbox is still in the development and testing phase and thus may have bugs. Please send any feedback to <a href="mailto:squadbox@mit.edu">squadbox@mit.edu</a> or open an issue on our <a href="https://github.com/amyxzhang/squadbox">GitHub repository</a>.</i>
 		<br><br>
-		{% endif %}
+		Note: use your own email address to sign up. You'll choose a Squadbox address later.
 		<form method='post' id='reg-form'>
-			{% csrf_token %}		
+			{% csrf_token %}
 			{{ form.as_p }}
 			<input type="submit" class="btn btn-primary" value="Register!" />
 		</form>


### PR DESCRIPTION
ideally we should figure out how to change the registration code to reject anyone trying to sign up with an @squadbox.org address, but at least this will clarify things a bit