### PR TITLE
User profile byte change

### DIFF
--- a/schema/models.py
+++ b/schema/models.py
@@ -262,7 +262,7 @@ class MyUserManager(BaseUserManager):
 class UserProfile(AbstractBaseUser):
 	email = models.EmailField(
         verbose_name='email address',
-        max_length=200,
+        max_length=250,
         unique=True,
     )
 	first_name = models.CharField('first name', max_length=30, blank=True)

--- a/schema/models.py
+++ b/schema/models.py
@@ -262,7 +262,7 @@ class MyUserManager(BaseUserManager):
 class UserProfile(AbstractBaseUser):
 	email = models.EmailField(
         verbose_name='email address',
-        max_length=255,
+        max_length=200,
         unique=True,
     )
 	first_name = models.CharField('first name', max_length=30, blank=True)
@@ -291,7 +291,8 @@ class UserProfile(AbstractBaseUser):
 		"""
         Sends an email to this User.
         """	
-		send_mail(subject, message, from_email, [self.email])
+		print(from_email)
+		send_mail(subject, message, from_email, [self.email], fail_silently=False)
 
 	def has_perm(self, perm, obj=None):
 		"Does the user have a specific permission?"

--- a/schema/models.py
+++ b/schema/models.py
@@ -291,7 +291,6 @@ class UserProfile(AbstractBaseUser):
 		"""
         Sends an email to this User.
         """	
-		print(from_email)
 		send_mail(subject, message, from_email, [self.email], fail_silently=False)
 
 	def has_perm(self, perm, obj=None):


### PR DESCRIPTION
Fixed an issue with the Login and Register. When creating the UserProfile Database the error would say "Specified key was too long; max key length is 1000 bytes". Changed max length of email address from 255 to 250 as 255 goes to 1020 bytes (1 character is 4 bytes). 